### PR TITLE
Update changelog link and autostart menu item label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           tagName: ${{ steps.version.outputs.version }}
           releaseName: "Ntfy App ${{ steps.version.outputs.version }}"
-          releaseBody: "See the [changelog](https://github.com/rubix-studios-pty-ltd/ntfy-app/CHANGELOG.md) for details."
+          releaseBody: "See the [changelog](https://github.com/rubix-studios-pty-ltd/ntfy-app/blob/main/CHANGELOG.md) for details."
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -14,7 +14,7 @@ pub fn setup_tray(app: &tauri::App) -> tauri::Result<()> {
   let autostart = CheckMenuItem::with_id(
     app,
     "autostart",
-    "Start on Boot",
+    "Boot On Startup",
     true,
     autostart_enabled,
     None::<&str>


### PR DESCRIPTION
This pull request includes minor updates to improve clarity and accuracy in both the GitHub Actions workflow and the application's tray menu.

Workflow and documentation:

* Updated the `releaseBody` link in `.github/workflows/build.yml` to point to the correct changelog file location on the `main` branch, ensuring users are directed to the latest changelog.

User interface text:

* Changed the tray menu label from "Start on Boot" to "Boot On Startup" in `src-tauri/src/tray.rs` for improved clarity or consistency.