### PR TITLE
docs: update macOS instructions and clarify development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ A cross-platform desktop client for [ntfy.sh](https://ntfy.sh) and self-hosted n
 - **Modern UI**: Built with Next.js, React, and Tailwind CSS
 - **Tray Integration**: System tray as a default for unobtrusive notifications
 
+## macOS
+
+macOS may block unsigned applications on first launch. Open Terminal and run the following command once before opening the app:
+
+```
+xattr -cr "/Applications/Ntfy App.app"
+```
+
 ## Prerequisites
 
 - **Node.js** 24.x or 25.x
@@ -60,7 +68,7 @@ For macOS, also install additional targets:
 rustup target add aarch64-apple-darwin x86_64-apple-darwin
 ```
 
-### Running in Development
+### Running Development
 
 Start the development server:
 ```bash


### PR DESCRIPTION
This pull request updates the `README.md` to improve setup instructions, especially for macOS users, and makes a minor wording adjustment for clarity.

**macOS setup instructions:**

* Added a section explaining how to bypass macOS's security block on unsigned applications by running `xattr -cr "/Applications/Ntfy App.app"` in Terminal before launching the app.

**Documentation improvements:**

* Changed the heading from "Running in Development" to "Running Development" for consistency.