### PR TITLE
Update autostart menu label and configure localhost plugin

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -57,6 +57,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +490,12 @@ dependencies = [
  "serde",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "combine"
@@ -1558,6 +1570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2204,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-localhost",
  "tauri-plugin-notification",
  "tauri-plugin-updater",
  "url",
@@ -3798,6 +3817,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-localhost"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8d72c024121b1a3d9268293d49a56baf01a8c785561c85d17872588b839e55"
+dependencies = [
+ "http",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tiny_http",
+]
+
+[[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4053,6 +4087,18 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ntfy-app"
 version = "0.0.4"
-description = "Desktop client for ntfy.sh and self-hosted ntfy instances on Windows, Linux, and macOS. Built with Rust, Tauri, and Next.js."
 authors = ["rubixvi"]
 description = "Desktop client for ntfy.sh and self-hosted ntfy instances on Windows, Linux, and macOS. Built with Rust, Tauri, and Next.js."
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,11 +14,11 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-url = "2"
 tauri = { version = "2.11.1", features = ["tray-icon"] }
+url = "2"
 auto-launch = "0.5"
-tauri-plugin-notification = "2"
 tauri-plugin-localhost = "2"
+tauri-plugin-notification = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "ntfy-app"
 version = "0.0.2"
-description = "Desktop client for ntfy.sh and self-hosted ntfy instances on Windows, Linux, and macOS. Built with Rust, Tauri, and Next.js."
 authors = ["rubixvi"]
+description = "Desktop client for ntfy.sh and self-hosted ntfy instances on Windows, Linux, and macOS. Built with Rust, Tauri, and Next.js."
 license = "MIT"
-repository = ""
+repository = "https://github.com/rubix-studios-pty-ltd/ntfy-app"
 edition = "2024"
 rust-version = "1.93.1"
 
@@ -18,6 +18,7 @@ url = "2"
 tauri = { version = "2.11.1", features = ["tray-icon"] }
 auto-launch = "0.5"
 tauri-plugin-notification = "2"
+tauri-plugin-localhost = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,7 +12,10 @@ use tray::setup_tray;
 use window::setup_window_events;
 
 pub fn run() {
+    let port: u16 = 1430;
+
     let app = tauri::Builder::default()
+        .plugin(tauri_plugin_localhost::Builder::new(port).build())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_notification::init())
         .invoke_handler(tauri::generate_handler![get_url, set_url])

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -2,6 +2,7 @@ use tauri::{
     Manager,
     menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
+    Url,
 };
 use tauri_plugin_updater::UpdaterExt;
 
@@ -12,18 +13,13 @@ pub fn setup_tray(app: &tauri::App) -> tauri::Result<()> {
 
     let autostart_enabled = crate::autostart::is_autostart_enabled();
 
-    let check_updates = MenuItem::with_id(
-        app,
-        "check_updates",
-        "Check Updates",
-        true,
-        None::<&str>
-    )?;
+    let check_updates =
+        MenuItem::with_id(app, "check_updates", "Check Updates", true, None::<&str>)?;
 
     let autostart = CheckMenuItem::with_id(
         app,
         "autostart",
-        "Run On Startup",
+        "Auto Start",
         true,
         autostart_enabled,
         None::<&str>,
@@ -68,44 +64,41 @@ pub fn setup_tray(app: &tauri::App) -> tauri::Result<()> {
                 }
             }
             "check_updates" => {
-              let handle = app.app_handle().clone();
+                let handle = app.app_handle().clone();
 
-              tauri::async_runtime::spawn(async move {
-                let updater = match handle.updater() {
-                  Ok(updater) => updater,
-                  Err(error) => {
-                    eprintln!("Failed to initialize updater: {error}");
-                    return;
-                  }
-                };
+                tauri::async_runtime::spawn(async move {
+                    let updater = match handle.updater() {
+                        Ok(updater) => updater,
+                        Err(error) => {
+                            eprintln!("Failed to initialize updater: {error}");
+                            return;
+                        }
+                    };
 
-                match updater.check().await {
-                  Ok(Some(update)) => {
-                    println!("Update available: {}", update.version);
+                    match updater.check().await {
+                        Ok(Some(update)) => {
+                            println!("Update available: {}", update.version);
 
-                    if let Err(error) = update
-                      .download_and_install(
-                        |_chunk_length, _content_length| {},
-                        || {},
-                      )
-                      .await
-                    {
-                      eprintln!("Failed to install update: {error}");
-                      return;
+                            if let Err(error) = update
+                                .download_and_install(|_chunk_length, _content_length| {}, || {})
+                                .await
+                            {
+                                eprintln!("Failed to install update: {error}");
+                                return;
+                            }
+
+                            handle.restart();
+                        }
+
+                        Ok(None) => {
+                            println!("No updates available");
+                        }
+
+                        Err(error) => {
+                            eprintln!("Failed to check for updates: {error}");
+                        }
                     }
-
-                    handle.restart();
-                  }
-
-                  Ok(None) => {
-                    println!("No updates available");
-                  }
-
-                  Err(error) => {
-                    eprintln!("Failed to check for updates: {error}");
-                  }
-                }
-              });
+                });
             }
             "reset_instance" => {
                 if let Err(error) = crate::config::clear_instance_url(app.app_handle()) {
@@ -147,9 +140,9 @@ pub fn setup_tray(app: &tauri::App) -> tauri::Result<()> {
                         .dev_url
                         .as_ref()
                         .map(|u| u.to_string())
-                        .unwrap_or_else(|| "app://localhost/".to_string());
+                        .unwrap_or_else(|| "http://localhost:1430".to_string());
 
-                    let _ = window.eval(&format!("window.location.replace('{}');", app_url));
+                    let _ = window.navigate(Url::parse(&app_url).unwrap());
 
                     let _ = window.show();
                     let _ = window.unminimize();

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -23,7 +23,7 @@ pub fn setup_tray(app: &tauri::App) -> tauri::Result<()> {
     let autostart = CheckMenuItem::with_id(
         app,
         "autostart",
-        "Boot On Startup",
+        "Run On Startup",
         true,
         autostart_enabled,
         None::<&str>,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,6 +34,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "windows": {
       "nsis": {
@@ -60,7 +61,10 @@
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDVBRTEzNjEwMTVDRkY4NDQKUldSRStNOFZFRGJoV3RkMnNyRkw3QmlCdzBranFwaFZjR2JiNisxSVR0OFRaOHhzamxRc09NRXYK",
       "endpoints": [
         "https://github.com/rubix-studios-pty-ltd/ntfy-app/releases/latest/download/latest.json"
-      ]
+      ],
+      "windows": {
+        "installMode": "passive"
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request introduces several improvements and refinements to the Tauri desktop client for ntfy. The main updates include the addition of a local server plugin, enhancements to the updater and tray menu, and configuration adjustments for better user experience and deployment.

**Plugin and updater enhancements:**

* Added the `tauri-plugin-localhost` dependency and initialized it on port `1430` to serve the app locally, improving development and deployment workflows. [[1]](diffhunk://#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39R21) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR15-R18)
* Enabled the creation of updater artifacts and set the updater install mode to "passive" in `tauri.conf.json`, streamlining update distribution and installation. [[1]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7R37) [[2]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L63-R67)

**Tray menu and window behavior improvements:**

* Updated the tray menu item label from "Boot On Startup" to "Auto Start" for clarity, and refactored related code for readability.
* Changed window navigation logic to use `window.navigate` with a parsed `Url` instead of `window.eval`, and set the default development URL to `http://localhost:1430` to align with the local server.
* Minor code style improvements and dependency import updates in `tray.rs`. [[1]](diffhunk://#diff-0bea2961e3937231c211171f636c33447060e687be7df305a15bea57bd74a5ddR5) [[2]](diffhunk://#diff-0bea2961e3937231c211171f636c33447060e687be7df305a15bea57bd74a5ddL87-R83)

**Project metadata:**

* Added the repository URL to `Cargo.toml` for better project attribution and discoverability.