### PR TITLE
Dev

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -57,12 +57,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,12 +484,6 @@ dependencies = [
  "serde",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "combine"
@@ -1570,12 +1558,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,7 +2186,6 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
- "tauri-plugin-localhost",
  "tauri-plugin-notification",
  "tauri-plugin-updater",
  "url",
@@ -3817,21 +3798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin-localhost"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8d72c024121b1a3d9268293d49a56baf01a8c785561c85d17872588b839e55"
-dependencies = [
- "http",
- "log",
- "serde",
- "serde_json",
- "tauri",
- "thiserror 2.0.18",
- "tiny_http",
-]
-
-[[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,18 +4053,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny_http"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
-dependencies = [
- "ascii",
- "chunked_transfer",
- "httpdate",
- "log",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,6 @@ serde_json = "1"
 tauri = { version = "2.11.1", features = ["tray-icon"] }
 url = "2"
 auto-launch = "0.5"
-tauri-plugin-localhost = "2"
 tauri-plugin-notification = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,10 +12,7 @@ use tray::setup_tray;
 use window::setup_window_events;
 
 pub fn run() {
-    let port: u16 = 1430;
-
     let app = tauri::Builder::default()
-        .plugin(tauri_plugin_localhost::Builder::new(port).build())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_notification::init())
         .invoke_handler(tauri::generate_handler![get_url, set_url])

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -140,7 +140,7 @@ pub fn setup_tray(app: &tauri::App) -> tauri::Result<()> {
                         .dev_url
                         .as_ref()
                         .map(|u| u.to_string())
-                        .unwrap_or_else(|| "http://localhost:1430".to_string());
+                        .unwrap_or_else(|| "tauri://localhost".to_string());
 
                     let _ = window.navigate(Url::parse(&app_url).unwrap());
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -140,10 +140,9 @@ pub fn setup_tray(app: &tauri::App) -> tauri::Result<()> {
                         .dev_url
                         .as_ref()
                         .map(|u| u.to_string())
-                        .unwrap_or_else(|| "tauri://localhost".to_string());
+                        .unwrap_or_else(|| "tauri://localhost/".to_string());
 
                     let _ = window.navigate(Url::parse(&app_url).unwrap());
-
                     let _ = window.show();
                     let _ = window.unminimize();
                     let _ = window.set_focus();


### PR DESCRIPTION
This pull request removes the use of the `tauri-plugin-localhost` dependency and updates the application's default local URL scheme to use the Tauri protocol. The most important changes are:

**Dependency Removal:**

* Removed the `tauri-plugin-localhost` dependency from `Cargo.toml`, simplifying the list of dependencies.

**Plugin and URL Handling Updates:**

* Removed initialization of the `tauri_plugin_localhost` plugin from the Tauri app builder in `lib.rs`, as it is no longer needed.
* Updated the default application URL in `setup_tray` from `http://localhost:1430` to the Tauri protocol URL `tauri://localhost/`, aligning with the new approach for local resource loading.