### PR TITLE
fix: update style ID in page load handler and simplify browsing data

### DIFF
--- a/src-tauri/src/overrides.rs
+++ b/src-tauri/src/overrides.rs
@@ -7,7 +7,7 @@ pub fn handle_page_load(window: &Webview, url: &Url) {
       r#"
       (() => {
         try {
-          const styleId = 'ntfy-desktop-cleanup-style';
+          const styleId = 'ntfy-style';
 
           if (!document.getElementById(styleId)) {
             const style = document.createElement('style');

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -106,40 +106,14 @@ pub fn setup_tray(app: &tauri::App) -> tauri::Result<()> {
                 }
 
                 if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.eval(
-                        r#"
-                          localStorage.clear();
-                          sessionStorage.clear();
-
-                          if ('caches' in window) {
-                            caches.keys().then(keys => {
-                              keys.forEach(key => caches.delete(key));
-                            });
-                          }
-
-                          if ('serviceWorker' in navigator) {
-                            navigator.serviceWorker.getRegistrations().then(registrations => {
-                              registrations.forEach(registration => registration.unregister());
-                            });
-                          }
-
-                          document.cookie.split(";").forEach(cookie => {
-                            document.cookie = cookie
-                              .replace(/^ +/, "")
-                              .replace(
-                                /=.*/,
-                                "=;expires=" + new Date().toUTCString() + ";path=/"
-                              );
-                          });
-                        "#,
-                    );
+                    let _ = window.clear_all_browsing_data();
 
                     let app_url = app
                         .config()
                         .build
                         .dev_url
                         .as_ref()
-                        .map(|u| u.to_string())
+                        .map(|url| url.to_string())
                         .unwrap_or_else(|| "tauri://localhost/".to_string());
 
                     let _ = window.navigate(Url::parse(&app_url).unwrap());


### PR DESCRIPTION
This pull request simplifies and improves the code related to clearing browsing data and naming conventions in the Tauri application. The most significant changes include replacing a manual JavaScript approach for clearing browsing data with a built-in API call and updating a style element ID for clarity.

**Improvements to browsing data clearing:**

* Replaced the manual JavaScript code for clearing localStorage, sessionStorage, caches, service workers, and cookies with a single call to the `clear_all_browsing_data()` method on the main window, making the code more concise and reliable. (`src-tauri/src/tray.rs`)

**Code clarity and consistency:**

* Renamed the injected style element ID from `'ntfy-desktop-cleanup-style'` to `'ntfy-style'` for consistency and clarity. (`src-tauri/src/overrides.rs`)