### PR TITLE
fix: ensure webhook window is unminimized before showing

### DIFF
--- a/src-tauri/src/windows/webhook.rs
+++ b/src-tauri/src/windows/webhook.rs
@@ -2,24 +2,29 @@ use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 
 pub fn open_webhook_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("webhook") {
+        let _ = window.unminimize();
         let _ = window.show();
         let _ = window.set_focus();
 
         return;
     }
 
-    if let Err(error) =
-        WebviewWindowBuilder::new(app, "webhook", WebviewUrl::App("/webhook".into()))
-            .title("Ntfy")
-            .inner_size(400.0, 500.0)
-            .resizable(true)
-            .fullscreen(false)
-            .decorations(true)
-            .visible(false)
-            .center()
-            .skip_taskbar(true)
-            .build()
+    match WebviewWindowBuilder::new(app, "webhook", WebviewUrl::App("/webhook".into()))
+        .title("Ntfy")
+        .inner_size(400.0, 500.0)
+        .resizable(true)
+        .fullscreen(false)
+        .decorations(true)
+        .center()
+        .skip_taskbar(true)
+        .build()
     {
-        eprintln!("Failed to create webhook window: {error}");
+        Ok(window) => {
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+        Err(error) => {
+            eprintln!("Failed to create webhook window: {error}");
+        }
     }
 }


### PR DESCRIPTION
- unminimize existing webhook window before focusing
- explicitly show newly created webhook window after build
- improve tray-triggered window restore reliability