### PR TITLE
fix: correct capitalization of "ntfy" in tray menu item

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -10,7 +10,7 @@ use crate::autostart::toggle_autostart;
 use crate::windows::webhook::open_webhook_window;
 
 pub fn setup_tray(app: &tauri::App) -> tauri::Result<()> {
-    let show = MenuItem::with_id(app, "open", "Open Ntfy", true, None::<&str>)?;
+    let show = MenuItem::with_id(app, "open", "Open ntfy", true, None::<&str>)?;
 
     let webhook = MenuItem::with_id(app, "webhook", "Webhook", true, None::<&str>)?;
 


### PR DESCRIPTION
This pull request makes a minor update to the tray menu label by changing the capitalization of "Ntfy" to "ntfy" for consistency.