### PR TITLE
fix: add asset name patterns for macOS, Linux, and Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,16 @@ jobs:
         include:
           - platform: 'macos-latest'
             args: '--target aarch64-apple-darwin'
+            assetNamePattern: 'Ntfy-macOS-Apple-Silicon[ext]'
           - platform: 'macos-latest'
             args: '--target x86_64-apple-darwin'
+            assetNamePattern: 'Ntfy-macOS-Intel[ext]'
           - platform: 'ubuntu-22.04'
             args: ''
+            assetNamePattern: 'Ntfy-Linux-x64[ext]'
           - platform: 'windows-latest'
             args: ''
+            assetNamePattern: 'Ntfy-Windows-x64-Setup[ext]'
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -86,3 +90,4 @@ jobs:
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}
+          releaseAssetNamePattern: ${{ matrix.assetNamePattern }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building release assets. The main change is the introduction of explicit asset naming patterns for each platform, which are now passed to the release step to ensure consistent and descriptive asset names in releases.

**Build asset naming improvements:**

* Added an `assetNamePattern` field to the build matrix for each platform in `.github/workflows/build.yml`, specifying clear and platform-specific asset names for release artifacts.
* Updated the release step to use the new `releaseAssetNamePattern` variable, ensuring assets are named according to the patterns defined in the matrix.