### PR TITLE
fix: remove unnecessary whitespace in baseSchema definition

### DIFF
--- a/schema/automation.ts
+++ b/schema/automation.ts
@@ -16,13 +16,10 @@ const optionalText = z.preprocess(
 const baseSchema = z.object({
   id: z.string().min(1),
   active: z.boolean(),
-
   name: z.string().trim().min(1, 'Name is required'),
   topic: z.string().trim().min(1, 'Topic is required'),
-
   matchType: matchTypeSchema,
   matchValue: z.string().trim().min(1, 'Match is required'),
-
   lastRun: optionalText,
   status: statusSchema.optional(),
 })


### PR DESCRIPTION
This pull request makes a minor change to the `schema/automation.ts` file by removing unnecessary blank lines within the `baseSchema` object definition to improve code readability.