### PR TITLE
Implement cross-platform volume control and system management features

### DIFF
--- a/modules/index.ts
+++ b/modules/index.ts
@@ -1,7 +1,8 @@
+import { systemModule } from '@/modules/system'
 import { type Module } from '@/modules/types'
 import { volumeModule } from '@/modules/volume'
 
-export const moduleOptions = [...volumeModule] satisfies Module[]
+export const moduleOptions = [...systemModule, ...volumeModule] satisfies Module[]
 
 export const moduleMap: Record<string, Module> = Object.fromEntries(
   moduleOptions.map((module) => [module.id, module])

--- a/modules/index.ts
+++ b/modules/index.ts
@@ -1,8 +1,9 @@
+import { screenModule } from '@/modules/screen'
 import { systemModule } from '@/modules/system'
 import { type Module } from '@/modules/types'
 import { volumeModule } from '@/modules/volume'
 
-export const moduleOptions = [...systemModule, ...volumeModule] satisfies Module[]
+export const moduleOptions = [...screenModule, ...systemModule, ...volumeModule] satisfies Module[]
 
 export const moduleMap: Record<string, Module> = Object.fromEntries(
   moduleOptions.map((module) => [module.id, module])

--- a/modules/screen/index.ts
+++ b/modules/screen/index.ts
@@ -1,0 +1,29 @@
+import { type Module } from '@/modules/types'
+
+export const screenModule = [
+  {
+    id: 'takeScreenshot',
+    label: 'Take screenshot',
+    description: 'Capture the primary screen and save it as a PNG file.',
+    defaultConfig: {
+      directory: '',
+      filename: '',
+    },
+    fields: [
+      {
+        key: 'directory',
+        label: 'Directory',
+        type: 'text',
+        allowVariables: true,
+        placeholder: 'Leave blank for the default screenshots folder',
+      },
+      {
+        key: 'filename',
+        label: 'Filename',
+        type: 'text',
+        allowVariables: true,
+        placeholder: 'Leave blank for sc-{date-time}.png',
+      },
+    ],
+  },
+] satisfies Module[]

--- a/modules/system/index.ts
+++ b/modules/system/index.ts
@@ -1,0 +1,29 @@
+import { type Module } from '@/modules/types'
+
+export const systemModule = [
+  {
+    id: 'hibernate',
+    label: 'Hibernate',
+    description: 'Hibernate the machine using the operating system power controls.',
+  },
+  {
+    id: 'logout',
+    label: 'Log out',
+    description: 'Log out the current user from the active operating system session.',
+  },
+  {
+    id: 'reboot',
+    label: 'Reboot',
+    description: 'Restart the machine using the operating system power controls.',
+  },
+  {
+    id: 'shutdown',
+    label: 'Shutdown',
+    description: 'Shut down the machine using the operating system power controls.',
+  },
+  {
+    id: 'sleep',
+    label: 'Sleep',
+    description: 'Put the machine into sleep mode using the operating system power controls.',
+  },
+] satisfies Module[]

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^1.16.0",
+    "lucide-react": "^1.17.0",
     "next": "^16.2.6",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
@@ -67,7 +67,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3",
-    "zustand": "^5.0.13"
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       lucide-react:
-        specifier: ^1.16.0
-        version: 1.16.0(react@19.2.6)
+        specifier: ^1.17.0
+        version: 1.17.0(react@19.2.6)
       next:
         specifier: ^16.2.6
         version: 16.2.6(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -42,8 +42,8 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
       zustand:
-        specifier: ^5.0.13
-        version: 5.0.13(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
+        specifier: ^5.0.14
+        version: 5.0.14(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.16
@@ -2236,8 +2236,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@1.16.0:
-    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
+  lucide-react@1.17.0:
+    resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -2905,8 +2905,8 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
-  zustand@5.0.13:
-    resolution: {integrity: sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==}
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -4947,7 +4947,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@1.16.0(react@19.2.6):
+  lucide-react@1.17.0(react@19.2.6):
     dependencies:
       react: 19.2.6
 
@@ -5683,7 +5683,7 @@ snapshots:
 
   zod@4.4.3: {}
 
-  zustand@5.0.13(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
+  zustand@5.0.14(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
     optionalDependencies:
       '@types/react': 19.2.15
       react: 19.2.6

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2273,6 +2273,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "system_shutdown",
  "tauri",
  "tauri-build",
  "tauri-plugin-notification",
@@ -3807,6 +3808,16 @@ dependencies = [
  "pkg-config",
  "toml 0.8.2",
  "version-compare",
+]
+
+[[package]]
+name = "system_shutdown"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29396e5e1b637d102ec5037bf7fbb8da78264fa299101ced9ce827756b1bac02"
+dependencies = [
+ "windows 0.62.2",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -42,6 +42,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,7 +123,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -138,7 +154,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -164,7 +180,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -207,7 +223,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -247,6 +263,25 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "annotate-snippets",
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bit-set"
@@ -350,12 +385,32 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -388,7 +443,7 @@ checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -450,6 +505,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,7 +531,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -489,9 +563,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -514,6 +601,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +618,12 @@ dependencies = [
  "time",
  "version_check",
 ]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
 name = "core-foundation"
@@ -787,6 +889,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.7.4",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,12 +936,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "drm"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytemuck",
+ "drm-ffi",
+ "drm-fourcc",
+ "libc",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "drm-ffi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51a91c9b32ac4e8105dec255e849e0d66e27d7c34d184364fb93e469db08f690"
+dependencies = [
+ "drm-sys",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "drm-fourcc"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
+
+[[package]]
+name = "drm-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8e1361066d91f5ffccff060a3c3be9c3ecde15be2959c1937595f7a82a9f8"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.9.4",
 ]
 
 [[package]]
@@ -874,6 +1031,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embed-resource"
@@ -1172,6 +1335,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "gbm"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce852e998d3ca5e4a97014fb31c940dc5ef344ec7d364984525fd11e8a547e6a"
+dependencies = [
+ "bitflags 2.11.1",
+ "drm",
+ "drm-fourcc",
+ "gbm-sys",
+ "libc",
+ "wayland-backend",
+ "wayland-server",
+]
+
+[[package]]
+name = "gbm-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13a5f2acc785d8fb6bf6b7ab6bfb0ef5dad4f4d97e8e70bb8e470722312f76f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "gdk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,7 +1396,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1226,7 +1413,7 @@ dependencies = [
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1240,7 +1427,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1266,7 +1453,7 @@ dependencies = [
  "gdk-sys",
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "x11",
 ]
 
@@ -1344,8 +1531,28 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "winapi",
+]
+
+[[package]]
+name = "gl"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94edab108827d67608095e269cf862e60d920f144a5026d3dbcfd8b877fb404"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
 ]
 
 [[package]]
@@ -1392,7 +1599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1409,7 +1616,7 @@ checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1448,7 +1655,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pango-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1784,6 +1991,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,6 +2061,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,7 +2095,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1989,6 +2218,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,7 +2259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2041,6 +2286,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2080,6 +2335,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "libspa"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b8cfa2a7656627b4c92c6b9ef929433acd673d5ab3708cda1b18478ac00df4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cc",
+ "convert_case",
+ "cookie-factory",
+ "libc",
+ "libspa-sys",
+ "nix 0.30.1",
+ "nom 8.0.0",
+ "system-deps 7.0.8",
+]
+
+[[package]]
+name = "libspa-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "901049455d2eb6decf9058235d745237952f4804bc584c5fcb41412e6adcc6e0"
+dependencies = [
+ "bindgen",
+ "cc",
+ "system-deps 7.0.8",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,6 +2372,39 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "libwayshot-xcap"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558a3a7ca16a17a14adf8f051b3adcd7766d397532f5f6d6a48034db11e54c22"
+dependencies = [
+ "drm",
+ "gbm",
+ "gl",
+ "image",
+ "khronos-egl",
+ "memmap2",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "tracing",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2147,6 +2463,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,6 +2485,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minisign-verify"
@@ -2186,6 +2517,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -2241,6 +2582,18 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
@@ -2249,6 +2602,25 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2270,7 +2642,9 @@ name = "ntfy_app"
 version = "0.0.11"
 dependencies = [
  "auto-launch",
+ "chrono",
  "rusqlite",
+ "sanitize-filename",
  "serde",
  "serde_json",
  "system_shutdown",
@@ -2284,6 +2658,7 @@ dependencies = [
  "uuid",
  "volumecontrol",
  "windows 0.62.2",
+ "xcap",
 ]
 
 [[package]]
@@ -2352,8 +2727,48 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-av-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-avf-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-image-io",
+ "objc2-media-toolbox",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2374,7 +2789,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
 dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -2383,6 +2811,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2394,7 +2823,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -2405,10 +2836,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -2432,6 +2866,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,6 +2891,21 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -2472,6 +2937,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-image-io"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2480,6 +2956,29 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-media-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd9fdde720df3da7046bb9097811000c1e7ab5cd579fa89d96b27d56781fb30"
+dependencies = [
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-media",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2623,7 +3122,7 @@ checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
 dependencies = [
  "android_system_properties",
  "log",
- "nix",
+ "nix 0.31.3",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -2666,7 +3165,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2781,6 +3280,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "pipewire"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9688b89abf11d756499f7c6190711d6dbe5a3acdb30c8fbf001d6596d06a8d44"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "libc",
+ "libspa",
+ "libspa-sys",
+ "nix 0.30.1",
+ "once_cell",
+ "pipewire-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "pipewire-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb028afee0d6ca17020b090e3b8fa2d7de23305aef975c7e5192a5050246ea36"
+dependencies = [
+ "bindgen",
+ "libspa-sys",
+ "system-deps 7.0.8",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,7 +3362,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2939,6 +3466,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3179,6 +3721,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3186,7 +3741,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3279,6 +3834,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sanitize-filename"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc984f4f9ceb736a7bb755c3e3bd17dc56370af2600c9780dcc48c66453da34d"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,6 +3901,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3688,7 +4258,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3803,10 +4373,23 @@ version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
  "heck 0.5.0",
  "pkg-config",
  "toml 0.8.2",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr 0.20.8",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 1.1.2+spec-1.1.0",
  "version-compare",
 ]
 
@@ -3887,6 +4470,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tauri"
@@ -4222,7 +4811,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4670,6 +5259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4967,6 +5562,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-server"
+version = "0.31.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1846eb04c49182e04f4a099e2a830a2b745610bbc1d61246e206f29c7000a0"
+dependencies = [
+ "bitflags 2.11.1",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "libc",
+ "log",
+ "memoffset",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5029,7 +5712,7 @@ dependencies = [
  "libc",
  "pkg-config",
  "soup3-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -5076,6 +5759,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -5779,8 +6468,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
+
+[[package]]
+name = "xcap"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ad471d5ba232bc276382d26a9d3b837d6853b7df389058b5bb1e94dcdd248c"
+dependencies = [
+ "dispatch2",
+ "image",
+ "libwayshot-xcap",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-av-foundation",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-media",
+ "objc2-core-video",
+ "objc2-foundation",
+ "percent-encoding",
+ "pipewire",
+ "rand",
+ "scopeguard",
+ "serde",
+ "thiserror 2.0.18",
+ "url",
+ "widestring",
+ "windows 0.62.2",
+ "xcb",
+ "zbus",
+]
+
+[[package]]
+name = "xcb"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "quick-xml 0.30.0",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "yoke"
@@ -5827,7 +6564,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2044,6 +2044,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "libpulse-binding"
+version = "2.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909eb3049e16e373680fe65afe6e2a722ace06b671250cc4849557bc57d6a397"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "libpulse-sys",
+ "num-derive",
+ "num-traits",
+ "winapi",
+]
+
+[[package]]
+name = "libpulse-sys"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74371848b22e989f829cc1621d2ebd74960711557d8b45cfe740f60d0a05e61"
+dependencies = [
+ "libc",
+ "num-derive",
+ "num-traits",
+ "pkg-config",
+ "winapi",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,6 +2281,7 @@ dependencies = [
  "tauri-plugin-updater",
  "url",
  "uuid",
+ "volumecontrol",
  "windows 0.62.2",
 ]
 
@@ -2262,6 +2290,17 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-traits"
@@ -2326,6 +2365,15 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4688,6 +4736,59 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "volumecontrol"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dbcf995be139d3798334cc7690d4ab26a7b525ff0a5792507151e153ea2c637"
+dependencies = [
+ "volumecontrol-core",
+ "volumecontrol-linux",
+ "volumecontrol-macos",
+ "volumecontrol-windows",
+]
+
+[[package]]
+name = "volumecontrol-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfff75d0fba84a608808b8ef3a7f85a35690e8278bbe696d08559e69bb676cd6"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "volumecontrol-linux"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdca786f6f6b58d43702d0623ab637b7e747215cb18f7ad53d75dbf2b39dc711"
+dependencies = [
+ "libpulse-binding",
+ "volumecontrol-core",
+]
+
+[[package]]
+name = "volumecontrol-macos"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e71f6d8c3cf1fd2b398d8ee54df8e262de03286897a78a8e435e828028363a"
+dependencies = [
+ "objc2-core-audio",
+ "objc2-core-foundation",
+ "volumecontrol-core",
+]
+
+[[package]]
+name = "volumecontrol-windows"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46dfa7183cb1892b9cb7743c1bb81e87f6b79c7f26f604200a1b5d4474a39713"
+dependencies = [
+ "thiserror 2.0.18",
+ "volumecontrol-core",
+ "windows 0.62.2",
+]
 
 [[package]]
 name = "vswhom"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,5 +37,8 @@ windows = { version = "0.62.2", features = [
   "Win32_System_Variant",
 ] }
 
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+volumecontrol = "0.1.4"
+
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-process = "2"
 auto-launch = "0.6"
 rusqlite = { version = "0.40.0", features = ["bundled"] }
+system_shutdown = "4.1.0"
 uuid = { version = "1.23.1", features = ["v4"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,9 +24,12 @@ tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-process = "2"
 auto-launch = "0.6"
+chrono = "0.4"
 rusqlite = { version = "0.40.0", features = ["bundled"] }
+sanitize-filename = "0.6"
 system_shutdown = "4.1.0"
 uuid = { version = "1.23.1", features = ["v4"] }
+xcap = "0.9.6"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62.2", features = [

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,3 +1,4 @@
 pub mod registry;
+pub mod screen;
 pub mod sound;
 pub mod system;

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,2 +1,3 @@
 pub mod registry;
 pub mod sound;
+pub mod system;

--- a/src-tauri/src/modules/registry.rs
+++ b/src-tauri/src/modules/registry.rs
@@ -1,11 +1,34 @@
-use super::{sound, system};
+use super::{screen, sound, system};
 
 use crate::automation::matcher::MatchContext;
 use crate::automation::modules::ModuleField;
 use crate::db::models::AutomationRule;
 
+type Fields = fn(&str) -> Option<&'static [ModuleField]>;
+type Execute = fn(&str, &AutomationRule, &MatchContext) -> Result<(), String>;
+
+struct ModuleHandler {
+    fields: Fields,
+    execute: Execute,
+}
+
+const MODULES: &[ModuleHandler] = &[
+    ModuleHandler {
+        fields: sound::fields,
+        execute: sound::execute,
+    },
+    ModuleHandler {
+        fields: system::fields,
+        execute: system::execute,
+    },
+    ModuleHandler {
+        fields: screen::fields,
+        execute: screen::execute,
+    },
+];
+
 pub fn fields(module_id: &str) -> Option<&'static [ModuleField]> {
-    sound::fields(module_id).or_else(|| system::fields(module_id))
+    MODULES.iter().find_map(|module| (module.fields)(module_id))
 }
 
 pub fn execute(rule: &AutomationRule, context: &MatchContext) -> Result<(), String> {
@@ -16,13 +39,10 @@ pub fn execute(rule: &AutomationRule, context: &MatchContext) -> Result<(), Stri
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "Module is required".to_string())?;
 
-    if sound::fields(module_id).is_some() {
-        return sound::execute(module_id, rule, context);
-    }
+    let module = MODULES
+        .iter()
+        .find(|module| (module.fields)(module_id).is_some())
+        .ok_or_else(|| format!("Unknown module: {module_id}"))?;
 
-    if system::fields(module_id).is_some() {
-        return system::execute(module_id, rule, context);
-    }
-
-    Err(format!("Unknown module: {module_id}"))
+    (module.execute)(module_id, rule, context)
 }

--- a/src-tauri/src/modules/registry.rs
+++ b/src-tauri/src/modules/registry.rs
@@ -1,11 +1,11 @@
-use super::sound;
+use super::{sound, system};
 
 use crate::automation::matcher::MatchContext;
 use crate::automation::modules::ModuleField;
 use crate::db::models::AutomationRule;
 
 pub fn fields(module_id: &str) -> Option<&'static [ModuleField]> {
-    sound::fields(module_id)
+    sound::fields(module_id).or_else(|| system::fields(module_id))
 }
 
 pub fn execute(rule: &AutomationRule, context: &MatchContext) -> Result<(), String> {
@@ -16,5 +16,13 @@ pub fn execute(rule: &AutomationRule, context: &MatchContext) -> Result<(), Stri
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "Module is required".to_string())?;
 
-    sound::execute(module_id, rule, context)
+    if sound::fields(module_id).is_some() {
+        return sound::execute(module_id, rule, context);
+    }
+
+    if system::fields(module_id).is_some() {
+        return system::execute(module_id, rule, context);
+    }
+
+    Err(format!("Unknown module: {module_id}"))
 }

--- a/src-tauri/src/modules/screen/mod.rs
+++ b/src-tauri/src/modules/screen/mod.rs
@@ -1,0 +1,166 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use chrono::Local;
+use xcap::Monitor;
+
+use crate::automation::matcher::MatchContext;
+use crate::automation::modules::{FieldKind, ModuleField};
+use crate::automation::tokens::replace_tokens;
+use crate::db::models::{ActionConfig, AutomationRule};
+
+const FIELDS: &[ModuleField] = &[
+    ModuleField {
+        key: "directory",
+        kind: FieldKind::Text,
+        min: None,
+        max: None,
+        allow_variables: true,
+        options: &[],
+    },
+    ModuleField {
+        key: "filename",
+        kind: FieldKind::Text,
+        min: None,
+        max: None,
+        allow_variables: true,
+        options: &[],
+    },
+];
+
+pub fn fields(module_id: &str) -> Option<&'static [ModuleField]> {
+    match module_id {
+        "takeScreenshot" => Some(FIELDS),
+        _ => None,
+    }
+}
+
+pub fn execute(
+    module_id: &str,
+    rule: &AutomationRule,
+    context: &MatchContext,
+) -> Result<(), String> {
+    match module_id {
+        "takeScreenshot" => take_screenshot(rule.action_config.as_ref(), context),
+        _ => Err(format!("Unknown screen module: {module_id}")),
+    }
+}
+
+fn take_screenshot(config: Option<&ActionConfig>, context: &MatchContext) -> Result<(), String> {
+    let directory = text_config(config, "directory")
+        .map(|value| replace_tokens(&value, context))
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(default_directory);
+
+    fs::create_dir_all(&directory)
+        .map_err(|error| format!("Failed to create screenshot directory: {error}"))?;
+
+    let filename = text_config(config, "filename")
+        .map(|value| replace_tokens(&value, context))
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(default_filename);
+
+    let path = unique_path(&directory, filename);
+
+    let monitor = primary_monitor()?;
+
+    let image = monitor
+        .capture_image()
+        .map_err(|error| format!("Failed to capture screenshot: {error}"))?;
+
+    image
+        .save(&path)
+        .map_err(|error| format!("Failed to save screenshot: {error}"))?;
+
+    Ok(())
+}
+
+fn primary_monitor() -> Result<Monitor, String> {
+    let monitors = Monitor::all().map_err(|error| format!("Failed to list monitors: {error}"))?;
+
+    if monitors.is_empty() {
+        return Err("No monitors found".to_string());
+    }
+
+    let mut fallback = None;
+
+    for monitor in monitors {
+        if fallback.is_none() {
+            fallback = Some(monitor.clone());
+        }
+
+        if monitor.is_primary().unwrap_or(false) {
+            return Ok(monitor);
+        }
+    }
+
+    fallback.ok_or_else(|| "No monitor available".to_string())
+}
+
+fn text_config(config: Option<&ActionConfig>, key: &str) -> Option<String> {
+    config?
+        .get(key)?
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn default_directory() -> PathBuf {
+    home_directory()
+        .map(|home| home.join("Pictures").join("Ntfy App").join("Screenshots"))
+        .unwrap_or_else(|| PathBuf::from("screenshots"))
+}
+
+fn home_directory() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+fn default_filename() -> String {
+    format!("sc-{}.png", Local::now().format("%Y%m%d-%H%M%S-%3f"))
+}
+
+fn unique_path(directory: &Path, filename: String) -> PathBuf {
+    let mut filename = sanitize_filename::sanitize(filename.trim());
+
+    if filename.is_empty() {
+        filename = default_filename();
+    }
+
+    let filename = png_extension(filename);
+    let initial_path = directory.join(&filename);
+
+    if !initial_path.exists() {
+        return initial_path;
+    }
+
+    let stem = Path::new(&filename)
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("screenshot");
+
+    for index in 2.. {
+        let candidate = directory.join(format!("{stem}-{index}.png"));
+
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+
+    unreachable!("File name should always be unique")
+}
+
+fn png_extension(filename: String) -> String {
+    let mut path = PathBuf::from(filename);
+    path.set_extension("png");
+
+    path.file_name()
+        .and_then(|value| value.to_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(default_filename)
+}

--- a/src-tauri/src/modules/sound/linux.rs
+++ b/src-tauri/src/modules/sound/linux.rs
@@ -1,0 +1,213 @@
+use std::process::Command;
+
+use volumecontrol::AudioDevice;
+
+fn percent(value: f64) -> u8 {
+    value.clamp(0.0, 100.0).round() as u8
+}
+
+fn percent_arg(value: f64) -> String {
+    format!("{}%", percent(value))
+}
+
+fn device() -> Result<AudioDevice, String> {
+    AudioDevice::from_default()
+        .map_err(|error| format!("Failed to get default audio device: {error}"))
+}
+
+fn run_command(program: &str, args: Vec<String>) -> Result<(), String> {
+    let output = Command::new(program)
+        .args(&args)
+        .output()
+        .map_err(|error| format!("Failed to run {program}: {error}"))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+    if stderr.is_empty() {
+        Err(format!("{program} failed with status {}", output.status))
+    } else {
+        Err(format!("{program} failed: {stderr}"))
+    }
+}
+
+fn run_fallbacks(
+    initial_error: String,
+    commands: Vec<(&'static str, Vec<String>)>,
+) -> Result<(), String> {
+    let mut errors = vec![format!("volumecontrol failed: {initial_error}")];
+
+    for (program, args) in commands {
+        match run_command(program, args) {
+            Ok(()) => return Ok(()),
+            Err(error) => errors.push(error),
+        }
+    }
+
+    Err(format!(
+        "No Linux volume backend worked: {}",
+        errors.join(" | ")
+    ))
+}
+
+fn try_with_fallbacks(
+    rust_backend: impl FnOnce() -> Result<(), String>,
+    commands: Vec<(&'static str, Vec<String>)>,
+) -> Result<(), String> {
+    match rust_backend() {
+        Ok(()) => Ok(()),
+        Err(error) => run_fallbacks(error, commands),
+    }
+}
+
+fn rust_set_volume(volume: f64) -> Result<(), String> {
+    device()?
+        .set_vol(percent(volume))
+        .map_err(|error| format!("Failed to set volume: {error}"))
+}
+
+fn rust_increase_volume(amount: f64) -> Result<(), String> {
+    let device = device()?;
+
+    let current = device
+        .get_vol()
+        .map_err(|error| format!("Failed to read volume: {error}"))?;
+
+    let next = current.saturating_add(percent(amount)).min(100);
+
+    device
+        .set_vol(next)
+        .map_err(|error| format!("Failed to increase volume: {error}"))
+}
+
+fn rust_decrease_volume(amount: f64) -> Result<(), String> {
+    let device = device()?;
+
+    let current = device
+        .get_vol()
+        .map_err(|error| format!("Failed to read volume: {error}"))?;
+
+    let next = current.saturating_sub(percent(amount));
+
+    device
+        .set_vol(next)
+        .map_err(|error| format!("Failed to decrease volume: {error}"))
+}
+
+fn rust_toggle_mute() -> Result<(), String> {
+    let device = device()?;
+
+    let muted = device
+        .is_mute()
+        .map_err(|error| format!("Failed to read mute state: {error}"))?;
+
+    device
+        .set_mute(!muted)
+        .map_err(|error| format!("Failed to toggle mute: {error}"))
+}
+
+pub fn set_volume(volume: f64) -> Result<(), String> {
+    let clamped_volume = volume.clamp(0.0, 100.0);
+    let volume_arg = percent_arg(clamped_volume);
+
+    try_with_fallbacks(
+        || rust_set_volume(clamped_volume),
+        vec![
+            (
+                "wpctl",
+                vec![
+                    "set-volume".into(),
+                    "@DEFAULT_SINK@".into(),
+                    volume_arg.clone(),
+                    "--limit".into(),
+                    "1.0".into(),
+                ],
+            ),
+            (
+                "pactl",
+                vec![
+                    "set-sink-volume".into(),
+                    "@DEFAULT_SINK@".into(),
+                    volume_arg,
+                ],
+            ),
+        ],
+    )
+}
+
+pub fn increase_volume(amount: f64) -> Result<(), String> {
+    let amount = percent(amount);
+    let wpctl_amount = format!("{amount}%+");
+    let pactl_amount = format!("+{amount}%");
+
+    try_with_fallbacks(
+        || rust_increase_volume(amount as f64),
+        vec![
+            (
+                "wpctl",
+                vec![
+                    "set-volume".into(),
+                    "@DEFAULT_SINK@".into(),
+                    wpctl_amount,
+                    "--limit".into(),
+                    "1.0".into(),
+                ],
+            ),
+            (
+                "pactl",
+                vec![
+                    "set-sink-volume".into(),
+                    "@DEFAULT_SINK@".into(),
+                    pactl_amount,
+                ],
+            ),
+        ],
+    )
+}
+
+pub fn decrease_volume(amount: f64) -> Result<(), String> {
+    let amount = percent(amount);
+    let wpctl_amount = format!("{amount}%-");
+    let pactl_amount = format!("-{amount}%");
+
+    try_with_fallbacks(
+        || rust_decrease_volume(amount as f64),
+        vec![
+            (
+                "wpctl",
+                vec!["set-volume".into(), "@DEFAULT_SINK@".into(), wpctl_amount],
+            ),
+            (
+                "pactl",
+                vec![
+                    "set-sink-volume".into(),
+                    "@DEFAULT_SINK@".into(),
+                    pactl_amount,
+                ],
+            ),
+        ],
+    )
+}
+
+pub fn toggle_mute() -> Result<(), String> {
+    try_with_fallbacks(
+        rust_toggle_mute,
+        vec![
+            (
+                "wpctl",
+                vec!["set-mute".into(), "@DEFAULT_SINK@".into(), "toggle".into()],
+            ),
+            (
+                "pactl",
+                vec![
+                    "set-sink-mute".into(),
+                    "@DEFAULT_SINK@".into(),
+                    "toggle".into(),
+                ],
+            ),
+        ],
+    )
+}

--- a/src-tauri/src/modules/sound/macos.rs
+++ b/src-tauri/src/modules/sound/macos.rs
@@ -1,0 +1,56 @@
+use volumecontrol::AudioDevice;
+
+fn device() -> Result<AudioDevice, String> {
+    AudioDevice::from_default()
+        .map_err(|error| format!("Failed to get default audio device: {error}"))
+}
+
+fn percent(value: f64) -> u8 {
+    value.clamp(0.0, 100.0).round() as u8
+}
+
+pub fn set_volume(volume: f64) -> Result<(), String> {
+    device()?
+        .set_vol(percent(volume))
+        .map_err(|error| format!("Failed to set volume: {error}"))
+}
+
+pub fn increase_volume(amount: f64) -> Result<(), String> {
+    let device = device()?;
+
+    let current = device
+        .get_vol()
+        .map_err(|error| format!("Failed to read volume: {error}"))?;
+
+    let next = current.saturating_add(percent(amount)).min(100);
+
+    device
+        .set_vol(next)
+        .map_err(|error| format!("Failed to increase volume: {error}"))
+}
+
+pub fn decrease_volume(amount: f64) -> Result<(), String> {
+    let device = device()?;
+
+    let current = device
+        .get_vol()
+        .map_err(|error| format!("Failed to read volume: {error}"))?;
+
+    let next = current.saturating_sub(percent(amount));
+
+    device
+        .set_vol(next)
+        .map_err(|error| format!("Failed to decrease volume: {error}"))
+}
+
+pub fn toggle_mute() -> Result<(), String> {
+    let device = device()?;
+
+    let muted = device
+        .is_mute()
+        .map_err(|error| format!("Failed to read mute state: {error}"))?;
+
+    device
+        .set_mute(!muted)
+        .map_err(|error| format!("Failed to toggle mute: {error}"))
+}

--- a/src-tauri/src/modules/sound/system.rs
+++ b/src-tauri/src/modules/sound/system.rs
@@ -1,134 +1,31 @@
 #[cfg(target_os = "windows")]
-mod platform {
-    use std::ptr::null;
+#[path = "windows.rs"]
+mod platform;
 
-    use windows::Win32::{
-        Media::Audio::{
-            Endpoints::IAudioEndpointVolume, IMMDeviceEnumerator, MMDeviceEnumerator, eConsole,
-            eRender,
-        },
-        System::Com::{
-            CLSCTX_ALL, COINIT_MULTITHREADED, CoCreateInstance, CoInitializeEx, CoUninitialize,
-        },
-    };
+#[cfg(target_os = "macos")]
+#[path = "macos.rs"]
+mod platform;
 
-    struct ComGuard;
+#[cfg(target_os = "linux")]
+#[path = "linux.rs"]
+mod platform;
 
-    impl ComGuard {
-        fn new() -> Result<Self, String> {
-            unsafe {
-                CoInitializeEx(None, COINIT_MULTITHREADED)
-                    .ok()
-                    .map_err(|error| format!("Failed to initialise COM: {error}"))?;
-            }
-
-            Ok(Self)
-        }
-    }
-
-    impl Drop for ComGuard {
-        fn drop(&mut self) {
-            unsafe {
-                CoUninitialize();
-            }
-        }
-    }
-
-    fn with_endpoint<T>(
-        callback: impl FnOnce(&IAudioEndpointVolume) -> Result<T, String>,
-    ) -> Result<T, String> {
-        let _com = ComGuard::new()?;
-
-        let endpoint = unsafe {
-            let enumerator: IMMDeviceEnumerator =
-                CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL).map_err(|error| {
-                    format!("Failed to create audio device enumerator: {error}")
-                })?;
-
-            let device = enumerator
-                .GetDefaultAudioEndpoint(eRender, eConsole)
-                .map_err(|error| format!("Failed to get default audio endpoint: {error}"))?;
-
-            device
-                .Activate::<IAudioEndpointVolume>(CLSCTX_ALL, None)
-                .map_err(|error| format!("Failed to activate audio endpoint volume: {error}"))?
-        };
-
-        callback(&endpoint)
-    }
-
-    pub fn set_volume(volume: f64) -> Result<(), String> {
-        let scalar = (volume.clamp(0.0, 100.0) / 100.0) as f32;
-
-        with_endpoint(|endpoint| unsafe {
-            endpoint
-                .SetMasterVolumeLevelScalar(scalar, null())
-                .map_err(|error| format!("Failed to set volume: {error}"))
-        })
-    }
-
-    pub fn increase_volume(amount: f64) -> Result<(), String> {
-        let amount = (amount.clamp(0.0, 100.0) / 100.0) as f32;
-
-        with_endpoint(|endpoint| unsafe {
-            let current = endpoint
-                .GetMasterVolumeLevelScalar()
-                .map_err(|error| format!("Failed to read volume: {error}"))?;
-
-            let next = (current + amount).clamp(0.0, 1.0);
-
-            endpoint
-                .SetMasterVolumeLevelScalar(next, null())
-                .map_err(|error| format!("Failed to increase volume: {error}"))
-        })
-    }
-
-    pub fn decrease_volume(amount: f64) -> Result<(), String> {
-        let amount = (amount.clamp(0.0, 100.0) / 100.0) as f32;
-
-        with_endpoint(|endpoint| unsafe {
-            let current = endpoint
-                .GetMasterVolumeLevelScalar()
-                .map_err(|error| format!("Failed to read volume: {error}"))?;
-
-            let next = (current - amount).clamp(0.0, 1.0);
-
-            endpoint
-                .SetMasterVolumeLevelScalar(next, null())
-                .map_err(|error| format!("Failed to decrease volume: {error}"))
-        })
-    }
-
-    pub fn toggle_mute() -> Result<(), String> {
-        with_endpoint(|endpoint| unsafe {
-            let muted = endpoint
-                .GetMute()
-                .map_err(|error| format!("Failed to read mute state: {error}"))?
-                .as_bool();
-
-            endpoint
-                .SetMute(!muted, null())
-                .map_err(|error| format!("Failed to toggle mute: {error}"))
-        })
-    }
-}
-
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 mod platform {
     pub fn set_volume(_volume: f64) -> Result<(), String> {
-        Err("Volume control is only supported on Windows".to_string())
+        Err("Volume control is not supported on this platform".to_string())
     }
 
     pub fn increase_volume(_amount: f64) -> Result<(), String> {
-        Err("Volume control is only supported on Windows".to_string())
+        Err("Volume control is not supported on this platform".to_string())
     }
 
     pub fn decrease_volume(_amount: f64) -> Result<(), String> {
-        Err("Volume control is only supported on Windows".to_string())
+        Err("Volume control is not supported on this platform".to_string())
     }
 
     pub fn toggle_mute() -> Result<(), String> {
-        Err("Volume control is only supported on Windows".to_string())
+        Err("Volume control is not supported on this platform".to_string())
     }
 }
 

--- a/src-tauri/src/modules/sound/windows.rs
+++ b/src-tauri/src/modules/sound/windows.rs
@@ -1,0 +1,109 @@
+use std::ptr::null_mut;
+
+use windows::Win32::{
+    Media::Audio::{
+        Endpoints::IAudioEndpointVolume, IMMDeviceEnumerator, MMDeviceEnumerator, eConsole, eRender,
+    },
+    System::Com::{
+        CLSCTX_ALL, COINIT_MULTITHREADED, CoCreateInstance, CoInitializeEx, CoUninitialize,
+    },
+};
+
+struct ComGuard;
+
+impl ComGuard {
+    fn new() -> Result<Self, String> {
+        unsafe {
+            CoInitializeEx(None, COINIT_MULTITHREADED)
+                .ok()
+                .map_err(|error| format!("Failed to initialise COM: {error}"))?;
+        }
+
+        Ok(Self)
+    }
+}
+
+impl Drop for ComGuard {
+    fn drop(&mut self) {
+        unsafe {
+            CoUninitialize();
+        }
+    }
+}
+
+fn with_endpoint<T>(
+    callback: impl FnOnce(&IAudioEndpointVolume) -> Result<T, String>,
+) -> Result<T, String> {
+    let _com = ComGuard::new()?;
+
+    let endpoint = unsafe {
+        let enumerator: IMMDeviceEnumerator =
+            CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)
+                .map_err(|error| format!("Failed to create audio device enumerator: {error}"))?;
+
+        let device = enumerator
+            .GetDefaultAudioEndpoint(eRender, eConsole)
+            .map_err(|error| format!("Failed to get default audio endpoint: {error}"))?;
+
+        device
+            .Activate::<IAudioEndpointVolume>(CLSCTX_ALL, None)
+            .map_err(|error| format!("Failed to activate audio endpoint volume: {error}"))?
+    };
+
+    callback(&endpoint)
+}
+
+pub fn set_volume(volume: f64) -> Result<(), String> {
+    let scalar = (volume.clamp(0.0, 100.0) / 100.0) as f32;
+
+    with_endpoint(|endpoint| unsafe {
+        endpoint
+            .SetMasterVolumeLevelScalar(scalar, null_mut())
+            .map_err(|error| format!("Failed to set volume: {error}"))
+    })
+}
+
+pub fn increase_volume(amount: f64) -> Result<(), String> {
+    let amount = (amount.clamp(0.0, 100.0) / 100.0) as f32;
+
+    with_endpoint(|endpoint| unsafe {
+        let current = endpoint
+            .GetMasterVolumeLevelScalar()
+            .map_err(|error| format!("Failed to read volume: {error}"))?;
+
+        let next = (current + amount).clamp(0.0, 1.0);
+
+        endpoint
+            .SetMasterVolumeLevelScalar(next, null_mut())
+            .map_err(|error| format!("Failed to increase volume: {error}"))
+    })
+}
+
+pub fn decrease_volume(amount: f64) -> Result<(), String> {
+    let amount = (amount.clamp(0.0, 100.0) / 100.0) as f32;
+
+    with_endpoint(|endpoint| unsafe {
+        let current = endpoint
+            .GetMasterVolumeLevelScalar()
+            .map_err(|error| format!("Failed to read volume: {error}"))?;
+
+        let next = (current - amount).clamp(0.0, 1.0);
+
+        endpoint
+            .SetMasterVolumeLevelScalar(next, null_mut())
+            .map_err(|error| format!("Failed to decrease volume: {error}"))
+    })
+}
+
+pub fn toggle_mute() -> Result<(), String> {
+    with_endpoint(|endpoint| unsafe {
+        let muted = endpoint
+            .GetMute()
+            .map_err(|error| format!("Failed to read mute state: {error}"))?
+            .as_bool();
+
+        endpoint
+            .SetMute(!muted, null_mut())
+            .map_err(|error| format!("Failed to toggle mute: {error}"))
+    })
+}

--- a/src-tauri/src/modules/system/mod.rs
+++ b/src-tauri/src/modules/system/mod.rs
@@ -1,0 +1,37 @@
+use crate::automation::matcher::MatchContext;
+use crate::automation::modules::ModuleField;
+use crate::db::models::AutomationRule;
+
+pub fn fields(module_id: &str) -> Option<&'static [ModuleField]> {
+    match module_id {
+        "hibernate" | "logout" | "reboot" | "shutdown" | "sleep" => Some(&[]),
+        _ => None,
+    }
+}
+
+pub fn execute(
+    module_id: &str,
+    _rule: &AutomationRule,
+    _context: &MatchContext,
+) -> Result<(), String> {
+    match module_id {
+        "hibernate" => system_shutdown::hibernate()
+            .map_err(|error| format!("Failed to hibernate machine: {error}")),
+
+        "logout" => {
+            system_shutdown::logout().map_err(|error| format!("Failed to log out user: {error}"))
+        }
+
+        "reboot" => {
+            system_shutdown::reboot().map_err(|error| format!("Failed to reboot machine: {error}"))
+        }
+
+        "shutdown" => system_shutdown::shutdown()
+            .map_err(|error| format!("Failed to shut down machine: {error}")),
+
+        "sleep" => system_shutdown::sleep()
+            .map_err(|error| format!("Failed to put machine to sleep: {error}")),
+
+        _ => Err(format!("Unknown system module: {module_id}")),
+    }
+}


### PR DESCRIPTION
This pull request adds new system and screen automation modules, refactors the module registry for better extensibility, and introduces cross-platform (Linux and macOS) support for volume control using the `volumecontrol` Rust crate. Additionally, it updates several dependencies to their latest versions.

**Modules**

* Added a new `screen` module with a "Take screenshot" action, allowing automated screenshots with configurable directory and filename. This is implemented in both the frontend (`modules/screen/index.ts`) and backend (`src-tauri/src/modules/screen/mod.rs`). [[1]](diffhunk://#diff-4455ad49b076b1c574223c4e2cbd0a7b50bf04bf284d0de262ce3ca47eea34afR1-R29) [[2]](diffhunk://#diff-c6c9a091e97107bd3286635930f9419ea19ce61aefe976bffc2eab694be838f3R1-R166)
* Introduced a new `system` module with actions for hibernate, logout, reboot, shutdown, and sleep, available in the frontend and backend. [[1]](diffhunk://#diff-ed5b0b181cb85f01562a712122a3233c94b1691e6f04c664b70a4ada7f41dc9aR1-R29) [[2]](diffhunk://#diff-19848f76ac872c93ce509da7a03067bf972e353cc8774f9d02445e6db891f2c3R2-R4)

**Backend**

* Refactored the Rust module registry (`src-tauri/src/modules/registry.rs`) to use a more extensible handler pattern, supporting multiple modules and easier future expansion. [[1]](diffhunk://#diff-9f1ddd3d3c917c9ce947e47762b0a89098892f8a5ed1f2787240b12948cb1534L1-R31) [[2]](diffhunk://#diff-9f1ddd3d3c917c9ce947e47762b0a89098892f8a5ed1f2787240b12948cb1534L19-R47)
* Added cross-platform (Linux and macOS) volume control using the `volumecontrol` crate, with Linux fallback to system commands if the Rust backend fails. [[1]](diffhunk://#diff-73a0dc728d44f7e4e17e63621cdc84f11509b31696534db3bbcbf555ce830d69R1-R213) [[2]](diffhunk://#diff-dbe2555330efeb47e9b575736bfb47eb47e334c0a7e21a922736c4c36b383d2bR1-R56) [[3]](diffhunk://#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39R44-R46)

**Frontend**

* Registered the new `screen` and `system` modules in the frontend's `moduleOptions` and `moduleMap` for use in the application.
